### PR TITLE
[au] Remove call to Get-RemoteFiles to avoid bundling exe

### DIFF
--- a/jfrog-cli/update.ps1
+++ b/jfrog-cli/update.ps1
@@ -12,8 +12,6 @@ function global:au_SearchReplace {
     }
 }
 
-function global:au_BeforeUpdate { Get-RemoteFiles -Purge }
-
 function global:au_GetLatest {
     $pkg = Invoke-RestMethod -Uri "$pkgurl"
     write-debug "package: $pkg"


### PR DESCRIPTION
Should finally prevent bundling the executable in the package.